### PR TITLE
ci: add Pi AI Agent workflow

### DIFF
--- a/.github/workflows/pi.yml
+++ b/.github/workflows/pi.yml
@@ -1,0 +1,21 @@
+name: Pi AI Agent
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  pi-agent:
+    uses: shaftoe/pi-coding-agent-action/.github/workflows/pi.yml@v2
+    with:
+      allowed_actor: shaftoe
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.LLM_API_KEY }}


### PR DESCRIPTION
Adds the Pi AI Agent workflow (`.github/workflows/pi.yml`), mirroring the setup in [shaftoe/personal-website](https://github.com/shaftoe/personal-website/blob/master/.github/workflows/pi.yml).

This wires up the reusable Pi coding agent (`shaftoe/pi-coding-agent-action/.github/workflows/pi.yml@v2`) so it can be triggered via issue and PR review comments.

> **Note:** the `LLM_API_KEY` repository secret must be set for the agent to authenticate with the LLM provider. `GITHUB_TOKEN` is provided automatically.